### PR TITLE
Make GSS implement both lib/pq and jackc/pgconn

### DIFF
--- a/krb_unix.go
+++ b/krb_unix.go
@@ -22,7 +22,7 @@ import (
  * Keytab support is available only on unix systems
  */
 
-// GSS implements the pq.GSS interface.
+// GSS implements the pq.GSS interface and the pgconn.GSS interface.
 type GSS struct {
 	cli    *client.Client
 	ktPath string
@@ -127,7 +127,7 @@ func (g *GSS) GetInitToken(host string, service string) ([]byte, error) {
 	return g.GetInitTokenFromSPN(spn)
 }
 
-// GetInitTokenFromSpn implements the GSS interface.
+// GetInitTokenFromSPN implements the GSS interface.
 func (g *GSS) GetInitTokenFromSPN(spn string) ([]byte, error) {
 	s := spnego.SPNEGOClient(g.cli, spn)
 
@@ -142,6 +142,11 @@ func (g *GSS) GetInitTokenFromSPN(spn string) ([]byte, error) {
 	}
 
 	return b, nil
+}
+
+// GetInitTokenFromSpn implements the GSS interface.
+func (g *GSS) GetInitTokenFromSpn(spn string) ([]byte, error) {
+	return g.GetInitTokenFromSPN(spn)
 }
 
 // Continue implements the GSS interface.

--- a/krb_windows.go
+++ b/krb_windows.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alexbrainman/sspi/negotiate"
 )
 
-// GSS implements the pq.GSS interface.
+// GSS implements the pq.GSS interface and the pgconn.GSS interface.
 type GSS struct {
 	creds *sspi.Credentials
 	ctx   *negotiate.ClientContext
@@ -49,8 +49,8 @@ func (g *GSS) GetInitToken(host string, service string) ([]byte, error) {
 	return g.GetInitTokenFromSpn(spn)
 }
 
-// GetInitTokenFromSpn implements the GSS interface.
-func (g *GSS) GetInitTokenFromSpn(spn string) ([]byte, error) {
+// GetInitTokenFromSPN implements the GSS interface.
+func (g *GSS) GetInitTokenFromSPN(spn string) ([]byte, error) {
 	ctx, token, err := negotiate.NewClientContext(g.creds, spn)
 	if err != nil {
 		return nil, err
@@ -59,6 +59,11 @@ func (g *GSS) GetInitTokenFromSpn(spn string) ([]byte, error) {
 	g.ctx = ctx
 
 	return token, nil
+}
+
+// GetInitTokenFromSpn implements the GSS interface.
+func (g *GSS) GetInitTokenFromSpn(spn string) ([]byte, error) {
+	return g.GetInitTokenFromSPN(spn)
 }
 
 // Continue implements the GSS interface.


### PR DESCRIPTION
There was a sneaky little issue because the two libraries use different
spellings for one of the functions.

cc @otan 